### PR TITLE
[BUGFIX] Avoid implicitly nullable class method parameter

### DIFF
--- a/src/Load.php
+++ b/src/Load.php
@@ -114,7 +114,7 @@ class Load
         require_once($target);
     }
 
-    protected function loadPath(string $target, string $excludePattern = null): void
+    protected function loadPath(string $target, ?string $excludePattern = null): void
     {
         $absolutePath = $this->projectRoot . '/' . ltrim($target, '/\\');
         if (is_dir($absolutePath)) {


### PR DESCRIPTION
Resolves the 'implicitly nullable parameter' deprecation warning that appears in the shell when executing Deployer tasks with PHP 8.4.